### PR TITLE
fix(buildkite): Use snakeCaseName when referencing container in pipeline.yml

### DIFF
--- a/__tests__/buildkite.js
+++ b/__tests__/buildkite.js
@@ -7,7 +7,8 @@ describe('generator-seedrs-react:buildkite', () => {
   beforeAll(() => helpers
   .run(path.join(__dirname, '../generators/buildkite'))
   .withOptions({
-    kebabCaseName: 'seedrs-react-project'
+    kebabCaseName: 'seedrs-react-project',
+    snakeCaseName: 'seedrs_react_project'
   }));
 
   it('creates files', () => {
@@ -15,6 +16,19 @@ describe('generator-seedrs-react:buildkite', () => {
       './.buildkite/pipeline.yml',
       './.buildkite/steps/lint.sh',
       './.buildkite/steps/test.sh'
+    ]);
+  });
+
+  it('creates files with the correct output', () => {
+    assert.fileContent([
+      [
+        './.buildkite/pipeline.yml',
+        'run: seedrs_react_project'
+      ],
+      [
+        './.buildkite/pipeline.yml',
+        'queue: seedrs-react-project-agent'
+      ]
     ]);
   });
 });

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -17,7 +17,7 @@ module.exports = class extends Generator {
     const kebabCaseName = _.kebabCase(name);
 
     this.composeWith('generator-node/generators/git');
-    this.composeWith(require.resolve('../buildkite'), { kebabCaseName });
+    this.composeWith(require.resolve('../buildkite'), { kebabCaseName, snakeCaseName });
     this.composeWith(require.resolve('../webpack'), { kebabCaseName, snakeCaseName, port, embeddable });
     this.composeWith(require.resolve('../public'), { kebabCaseName, embeddable });
     this.composeWith(require.resolve('../scripts'));

--- a/generators/buildkite/index.js
+++ b/generators/buildkite/index.js
@@ -6,7 +6,10 @@ module.exports = class extends Generator {
     this.fs.copyTpl(
       this.templatePath('pipeline.yml.tpl'),
       this.destinationPath('./.buildkite/pipeline.yml'),
-      { kebabCaseName: this.options.kebabCaseName }
+      {
+        kebabCaseName: this.options.kebabCaseName,
+        snakeCaseName: this.options.snakeCaseName
+      }
     );
 
     this.fs.copy(

--- a/generators/buildkite/templates/pipeline.yml.tpl
+++ b/generators/buildkite/templates/pipeline.yml.tpl
@@ -4,7 +4,7 @@
       queue: <%= kebabCaseName %>-agent
     plugins:
       docker-compose#v2.2.0:
-        run: <%= kebabCaseName %>
+        run: <%= snakeCaseName %>
         config: docker-compose.yml
 
   - wait
@@ -15,5 +15,5 @@
       queue: <%= kebabCaseName %>-agent
     plugins:
       docker-compose#v2.2.0:
-        run: <%= kebabCaseName %>
+        run: <%= snakeCaseName %>
         config: docker-compose.buildkite.yml


### PR DESCRIPTION
## What does it do?

Fixes names of containers in pipeline.yml. Container names should always be snakecase.