### PR TITLE
No ticket remove bundle script tag plugin for webpack development

### DIFF
--- a/generators/webpack/templates/webpack.development.js.tpl
+++ b/generators/webpack/templates/webpack.development.js.tpl
@@ -2,11 +2,10 @@ const webpack = require('webpack');
 const merge = require('webpack-merge');
 const common = require('./webpack.common.js');
 <% if (embeddable) {%>
-const BundleScriptTagPlugin = require('@seedrs/bundle-script-tag-plugin');
-const { build, appPublic } = require('./paths');
+const { appPublic } = require('./paths');
 <% } else {%>
 const HtmlWebpackPlugin = require('html-webpack-plugin');
-const { build, appHtml, appPublic } = require('./paths');
+const { appHtml, appPublic } = require('./paths');
 <% } %>
 const { HOST } = require('./config');
 const { publicPath } = require('./env');

--- a/generators/webpack/templates/webpack.production.js.tpl
+++ b/generators/webpack/templates/webpack.production.js.tpl
@@ -43,29 +43,28 @@ module.exports = merge(common, {
     }),
 
 <% if (embeddable) {%>
-  new BundleScriptTagPlugin.default({
-    prefix: appName,
-    publicPath,
-    output: build
-  })
-<% } else {%>
-  new HtmlWebpackPlugin({
-      inject: true,
-      template: appHtml,
-      minify: {
-        removeComments: true,
-        collapseWhitespace: true,
-        removeRedundantAttributes: true,
-        useShortDoctype: true,
-        removeEmptyAttributes: true,
-        removeStyleLinkTypeAttributes: true,
-        keepClosingSlash: true,
-        minifyJS: true,
-        minifyCSS: true,
-        minifyURLs: true,
-      },
+    new BundleScriptTagPlugin.default({
+      prefix: appName,
+      publicPath,
+      output: build
     })
+<% } else {%>
+    new HtmlWebpackPlugin({
+        inject: true,
+        template: appHtml,
+        minify: {
+          removeComments: true,
+          collapseWhitespace: true,
+          removeRedundantAttributes: true,
+          useShortDoctype: true,
+          removeEmptyAttributes: true,
+          removeStyleLinkTypeAttributes: true,
+          keepClosingSlash: true,
+          minifyJS: true,
+          minifyCSS: true,
+          minifyURLs: true,
+        },
+      })
 <% } %>
   ]
 });
-


### PR DESCRIPTION
## What does it do?

* Removes the unused BundleScriptTagPlugin from `webpack.development.js.tpl`.
* Fixes the indentation so the generated file is consistent.